### PR TITLE
feat: expose indexes information

### DIFF
--- a/src/fountainDecoder.ts
+++ b/src/fountainDecoder.ts
@@ -225,15 +225,15 @@ export default class FountainDecoder {
   }
 
   public getExpectedPartIndexes(): PartIndexes {
-    return this.expectedPartIndexes
+    return [...this.expectedPartIndexes]
   }
 
   public getReceivedPartIndexes(): PartIndexes {
-    return this.receivedPartIndexes
+    return [...this.receivedPartIndexes]
   }
 
   public getLastPartIndexes(): PartIndexes {
-    return this.lastPartIndexes
+    return [...this.lastPartIndexes]
   }
 
   public estimatedPercentComplete(): number {

--- a/src/fountainDecoder.ts
+++ b/src/fountainDecoder.ts
@@ -224,6 +224,18 @@ export default class FountainDecoder {
     return this.expectedPartIndexes.length;
   }
 
+  public getExpectedPartIndexes(): PartIndexes {
+    return this.expectedPartIndexes
+  }
+
+  public getReceivedPartIndexes(): PartIndexes {
+    return this.receivedPartIndexes
+  }
+
+  public getLastPartIndexes(): PartIndexes {
+    return this.lastPartIndexes
+  }
+
   public estimatedPercentComplete(): number {
     if (this.isComplete()) {
       return 1;

--- a/src/urDecoder.ts
+++ b/src/urDecoder.ts
@@ -160,6 +160,18 @@ export default class URDecoder {
     return this.fountainDecoder.expectedPartCount();
   }
 
+  public expectedPartIndexes() {
+    return this.fountainDecoder.getExpectedPartIndexes();
+  }
+
+  public receivedPartIndexes() {
+    return this.fountainDecoder.getReceivedPartIndexes();
+  }
+
+  public lastPartIndexes() {
+    return this.fountainDecoder.getLastPartIndexes();
+  }
+
   public estimatedPercentComplete() {
     return this.fountainDecoder.estimatedPercentComplete();
   }


### PR DESCRIPTION
Exposing the indexes helps creating UIs that show a more detailed "progress bar".

Currently the original array is returned, so someone could manipulate it from the outside. I'm not sure if this is an issue, otherwise a copy could be returned.