### PR TITLE
feat: static from

### DIFF
--- a/src/ur.ts
+++ b/src/ur.ts
@@ -16,8 +16,8 @@ export default class UR {
     return new UR(cborEncode(buf));
   }
 
-  public static from(value: any) {
-    return UR.fromBuffer(Buffer.from(value));
+  public static from(value: any, encoding?: BufferEncoding) {
+    return UR.fromBuffer(Buffer.from(value, encoding));
   }
 
   public decodeCBOR(): Buffer {

--- a/src/ur.ts
+++ b/src/ur.ts
@@ -16,6 +16,10 @@ export default class UR {
     return new UR(cborEncode(buf));
   }
 
+  public static from(value: any) {
+    return UR.fromBuffer(Buffer.from(value));
+  }
+
   public decodeCBOR(): Buffer {
     return cborDecode(this._cborPayload);
   }


### PR DESCRIPTION
When building this library with browserify, the Buffer module is bundled internally. To avoid duplicating the code, it would be nice to have a method that will take any input and convert it to a buffer.