### PR TITLE
Refactor: remove unused cbor dependencies, replace `big-integer` with `JSBI`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bignumber.js": "^9.0.1",
     "cbor-sync": "^1.0.4",
     "crc": "^3.8.0",
+    "jsbi": "^3.1.5",
     "sha.js": "^2.4.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,15 +24,12 @@
   },
   "dependencies": {
     "@apocentre/alias-sampling": "^0.5.3",
-    "@ellipticoin/cbor": "^1.0.4",
-    "@iljucha/cbor": "^1.0.10",
     "@types/crc": "^3.4.0",
     "@types/sha.js": "^2.4.0",
     "assert": "^2.0.0",
     "big-integer": "^1.6.48",
     "bignumber.js": "^9.0.1",
     "cbor-sync": "^1.0.4",
-    "cborg": "^1.0.4",
     "crc": "^3.8.0",
     "sha.js": "^2.4.11"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/crc": "^3.4.0",
     "@types/sha.js": "^2.4.0",
     "assert": "^2.0.0",
-    "big-integer": "^1.6.48",
     "bignumber.js": "^9.0.1",
     "cbor-sync": "^1.0.4",
     "crc": "^3.8.0",

--- a/src/fountainDecoder.ts
+++ b/src/fountainDecoder.ts
@@ -262,7 +262,7 @@ export default class FountainDecoder {
       return 0;
     }
 
-    return Math.min(0.99, this.receivedPartIndexes.length / expectedPartCount);
+    return this.receivedPartIndexes.length / expectedPartCount;
   }
 }
 

--- a/src/fountainDecoder.ts
+++ b/src/fountainDecoder.ts
@@ -24,7 +24,6 @@ export class FountainDecoderPart {
   }
 }
 
-
 type PartIndexes = number[];
 interface PartDict {
   key: PartIndexes;
@@ -240,12 +239,15 @@ export default class FountainDecoder {
       return 1;
     }
 
-    const expectedPartCount = this.expectedPartCount() * 1.75;
+    const expectedPartCount = this.expectedPartCount();
 
     if (expectedPartCount === 0) {
       return 0;
     }
 
+    // We multiply the expectedPartCount by `1.75` as a way to compensate for the facet
+    // that `this.processedPartsCount` also tracks the duplicate parts that have been
+    // processeed.
     return Math.min(0.99, this.processedPartsCount / (expectedPartCount * 1.75));
   }
 

--- a/src/fountainDecoder.ts
+++ b/src/fountainDecoder.ts
@@ -199,11 +199,11 @@ export default class FountainDecoder {
   }
 
   public isComplete() {
-    return this.result !== undefined && this.result.length > 0;
+    return Boolean(this.result !== undefined && this.result.length > 0);
   }
 
   public isSuccess() {
-    return this.error === undefined && this.isComplete();
+    return Boolean(this.error === undefined && this.isComplete());
   }
 
   public resultMessage(): Buffer {

--- a/src/fountainDecoder.ts
+++ b/src/fountainDecoder.ts
@@ -190,7 +190,6 @@ export default class FountainDecoder {
     this.lastPartIndexes = decoderPart.indexes;
     this.queuedParts.push(decoderPart);
 
-
     while (!this.isComplete() && this.queuedParts.length > 0) {
       this.processQueuedItem();
     };
@@ -241,7 +240,7 @@ export default class FountainDecoder {
       return 1;
     }
 
-    const expectedPartCount = this.expectedPartCount();
+    const expectedPartCount = this.expectedPartCount() * 1.75;
 
     if (expectedPartCount === 0) {
       return 0;

--- a/src/urDecoder.ts
+++ b/src/urDecoder.ts
@@ -140,15 +140,15 @@ export default class URDecoder {
     return this.result ? this.result : new UR(Buffer.from([]));
   }
 
-  public isComplete() {
+  public isComplete(): boolean {
     return this.result && this.result.cbor.length > 0;
   }
 
-  public isSuccess() {
+  public isSuccess(): boolean {
     return !this.error && this.isComplete();
   }
 
-  public isError() {
+  public isError(): boolean {
     return this.error !== undefined;
   }
 

--- a/src/xoshiro.ts
+++ b/src/xoshiro.ts
@@ -1,62 +1,57 @@
 import { sha256Hash } from "./utils";
 import BigNumber from 'bignumber.js'
-import bigInt, { BigInteger } from 'big-integer'
 
 const MAX_UINT64 = 0xFFFFFFFFFFFFFFFF;
-const rotl = (x: BigInteger, k: number): BigInteger => asUintN(64, x.shiftLeft(k))
-  .or(
+const rotl = (x: bigint, k: number): bigint => asUintN(64, x << BigInt(k))
+   | BigInt(
     asUintN(
       64,
-      x.shiftRight((bigInt(64).minus(k)))
+      x >> (BigInt(64)- BigInt(k))
     )
   );
 
-const asUintN = (bits: number, bigint: BigInteger) => {
-  const p2bits = bigInt(1).shiftLeft(bits);
-  const mod = bigint.and(p2bits.subtract(1));
+const asUintN = (bits: number, bigint: bigint) => {
+  const p2bits = BigInt(1) << BigInt(bits);
+  const mod = bigint & BigInt(p2bits - BigInt(1));
   return mod
 };
 
 export default class Xoshiro {
-  private s: BigInteger[];
+  private s: bigint[];
 
   constructor(seed: Buffer) {
     const digest = sha256Hash(seed);
 
-    this.s = [bigInt(0), bigInt(0), bigInt(0), bigInt(0)];
+    this.s = [BigInt(0), BigInt(0), BigInt(0), BigInt(0)];
     this.setS(digest);
   }
 
   private setS(digest: Buffer) {
     for (let i = 0; i < 4; i++) {
       let o = i * 8;
-      let v = bigInt(0);
+      let v = BigInt(0);
       for (let n = 0; n < 8; n++) {
-        v = asUintN(64, v.shiftLeft(8));
-        v = asUintN(64, v.or(digest[o + n]));
+        v = asUintN(64, v << BigInt(8));
+        v = asUintN(64, v | BigInt(digest[o + n]));
       }
       this.s[i] = asUintN(64, v);
     }
   }
 
-  private roll(): BigInteger {
+  private roll(): bigint {
     const result = asUintN(
       64,
-      rotl(
-        asUintN(64, this.s[1].multiply(5)),
-        7
-      )
-        .multiply(9)
+      rotl(asUintN(64, this.s[1] * BigInt(5)), 7) * BigInt(9)
     );
 
-    const t = asUintN(64, this.s[1].shiftLeft(17));
+    const t = asUintN(64, this.s[1] << BigInt(17));
 
-    this.s[2] = asUintN(64, this.s[2].xor(this.s[0]));
-    this.s[3] = asUintN(64, this.s[3].xor(this.s[1]));
-    this.s[1] = asUintN(64, this.s[1].xor(this.s[2]));
-    this.s[0] = asUintN(64, this.s[0].xor(this.s[3]));
+    this.s[2] = asUintN(64, this.s[2] ^ BigInt(this.s[0]));
+    this.s[3] = asUintN(64, this.s[3] ^ BigInt(this.s[1]));
+    this.s[1] = asUintN(64, this.s[1] ^ BigInt(this.s[2]));
+    this.s[0] = asUintN(64, this.s[0] ^ BigInt(this.s[3]));
 
-    this.s[2] = asUintN(64, this.s[2].xor(t));
+    this.s[2] = asUintN(64, this.s[2] ^ BigInt(t));
 
     this.s[3] = asUintN(64, rotl(this.s[3], 45));
 

--- a/src/xoshiro.ts
+++ b/src/xoshiro.ts
@@ -1,59 +1,62 @@
 import { sha256Hash } from "./utils";
 import BigNumber from 'bignumber.js'
+import JSBI from 'jsbi'
 
 const MAX_UINT64 = 0xFFFFFFFFFFFFFFFF;
-const rotl = (x: bigint, k: number): bigint => asUintN(64, x << BigInt(k))
-   | BigInt(
-    asUintN(
+const rotl = (x: JSBI, k: number): JSBI => JSBI.bitwiseXor(
+  JSBI.asUintN(64, JSBI.leftShift(x, JSBI.BigInt(k))),
+  JSBI.BigInt(
+    JSBI.asUintN(
       64,
-      x >> (BigInt(64)- BigInt(k))
+      JSBI.signedRightShift(x, (JSBI.subtract(JSBI.BigInt(64), JSBI.BigInt(k))))
     )
-  );
-
-const asUintN = (bits: number, bigint: bigint) => {
-  const p2bits = BigInt(1) << BigInt(bits);
-  const mod = bigint & BigInt(p2bits - BigInt(1));
-  return mod
-};
+  )
+);
 
 export default class Xoshiro {
-  private s: bigint[];
+  private s: JSBI[];
 
   constructor(seed: Buffer) {
     const digest = sha256Hash(seed);
 
-    this.s = [BigInt(0), BigInt(0), BigInt(0), BigInt(0)];
+    this.s = [JSBI.BigInt(0), JSBI.BigInt(0), JSBI.BigInt(0), JSBI.BigInt(0)];
     this.setS(digest);
   }
 
   private setS(digest: Buffer) {
     for (let i = 0; i < 4; i++) {
       let o = i * 8;
-      let v = BigInt(0);
+      let v = JSBI.BigInt(0);
       for (let n = 0; n < 8; n++) {
-        v = asUintN(64, v << BigInt(8));
-        v = asUintN(64, v | BigInt(digest[o + n]));
+        v = JSBI.asUintN(64, JSBI.leftShift(v, JSBI.BigInt(8)));
+        v = JSBI.asUintN(64, JSBI.bitwiseOr(v, JSBI.BigInt(digest[o + n])));
       }
-      this.s[i] = asUintN(64, v);
+      this.s[i] = JSBI.asUintN(64, v);
     }
   }
 
-  private roll(): bigint {
-    const result = asUintN(
+  private roll(): JSBI {
+    const result = JSBI.asUintN(
       64,
-      rotl(asUintN(64, this.s[1] * BigInt(5)), 7) * BigInt(9)
+      JSBI.multiply(
+        rotl(
+          JSBI.asUintN(64, JSBI.multiply(this.s[1], JSBI.BigInt(5))),
+          7
+        ),
+        JSBI.BigInt(9)
+      )
     );
 
-    const t = asUintN(64, this.s[1] << BigInt(17));
+    const t = JSBI.asUintN(64, JSBI.leftShift(this.s[1], JSBI.BigInt(17)));
 
-    this.s[2] = asUintN(64, this.s[2] ^ BigInt(this.s[0]));
-    this.s[3] = asUintN(64, this.s[3] ^ BigInt(this.s[1]));
-    this.s[1] = asUintN(64, this.s[1] ^ BigInt(this.s[2]));
-    this.s[0] = asUintN(64, this.s[0] ^ BigInt(this.s[3]));
+    this.s[2] = JSBI.asUintN(64, JSBI.bitwiseXor(this.s[2], JSBI.BigInt(this.s[0])));
+    this.s[3] = JSBI.asUintN(64, JSBI.bitwiseXor(this.s[3], JSBI.BigInt(this.s[1])));
+    this.s[1] = JSBI.asUintN(64, JSBI.bitwiseXor(this.s[1], JSBI.BigInt(this.s[2])));
+    this.s[0] = JSBI.asUintN(64, JSBI.bitwiseXor(this.s[0], JSBI.BigInt(this.s[3])));
 
-    this.s[2] = asUintN(64, this.s[2] ^ BigInt(t));
+    this.s[2] = JSBI.asUintN(64, JSBI.bitwiseXor(this.s[2], JSBI.BigInt(t)));
 
-    this.s[3] = asUintN(64, rotl(this.s[3], 45));
+    this.s[3] = JSBI.asUintN(64, rotl(this.s[3], 45));
 
     return result;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,18 +283,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ellipticoin/cbor@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@ellipticoin/cbor/-/cbor-1.0.4.tgz#de5c5eb2aba9cee93a0a944fae2258171e231dd5"
-  integrity sha512-BD1kzgcYtr2RfG3yXl4aagJnyNpqo5snhzTUyWo1ss7GYSZRqIpEpc78NTm+fYCJ5n7TWrCUKBOqxQfhAkIyBQ==
-  dependencies:
-    bigint-buffer "^1.1.5"
-
-"@iljucha/cbor@^1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@iljucha/cbor/-/cbor-1.0.10.tgz#eb8f1cec52b1d7eacd21c721d31e441e87e36696"
-  integrity sha512-WEEFvEaLQceDj5J6NYFooMbk+l8FJIRYSnxGtwbO9+6rQ8aqRxQ3Nr4Qq0BpWnD/7wmqTAqupkpfomInQZ01PQ==
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -866,24 +854,10 @@ big-integer@^1.6.48:
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
   integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
 
-bigint-buffer@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/bigint-buffer/-/bigint-buffer-1.1.5.tgz#d038f31c8e4534c1f8d0015209bf34b4fa6dd442"
-  integrity sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==
-  dependencies:
-    bindings "^1.3.0"
-
 bignumber.js@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
   integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
-
-bindings@^1.3.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1002,11 +976,6 @@ cbor-sync@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cbor-sync/-/cbor-sync-1.0.4.tgz#5a11a1ab75c2a14d1af1b237fd84aa8c1593662f"
   integrity sha512-GWlXN4wiz0vdWWXBU71Dvc1q3aBo0HytqwAZnXF1wOwjqNnDWA1vZ1gDMFLlqohak31VQzmhiYfiCX5QSSfagA==
-
-cborg@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/cborg/-/cborg-1.0.4.tgz#6fc8160073bafbddb6fef34bf58cea1a24ed0ed6"
-  integrity sha512-/7DLFPNNmmwXSjfF34vln2stxQeeWg7lyAS/BU0U9yvjNCRBna33/npURK9BYQ5qU+6i4slJduEaBdVyz5ojTg==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -1516,11 +1485,6 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
-
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,11 +849,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-big-integer@^1.6.48:
-  version "1.6.48"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
-  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
-
 bignumber.js@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"


### PR DESCRIPTION
# Changes
- Removed unused cbor dependecies (#7)
- Replaced `big-integer` with`JSBI` to greatly improve performance (12 seconds vs 3 seconds when running the tests) (#7)

# Fixes
- Allow value of `1` to be returned from `getProgress`
- Always return a bool from `is*` functions
