### PR TITLE
fix: arraysEqual fn using index instead of element for comparison

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,7 +40,7 @@ export const arraysEqual = (ar1: any[], ar2: any[]): boolean => {
     return false;
   }
 
-  return ar1.every((el, index) => ar2.includes(index))
+  return ar1.every(el => ar2.includes(el))
 }
 
 /**


### PR DESCRIPTION
# Fixes
- `arraysEqual` helper function was trying to find if `ar2` includes an index of `ar1` instead of an element. This caused the comparison in the `FountainDecode.processMixedPart()` to always fail resulting in unnecessary processing of duplicate items