### PR TITLE
refactor: move some deps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
   },
   "dependencies": {
     "@apocentre/alias-sampling": "^0.5.3",
-    "@types/crc": "^3.4.0",
-    "@types/sha.js": "^2.4.0",
     "assert": "^2.0.0",
     "bignumber.js": "^9.0.1",
     "cbor-sync": "^1.0.4",
@@ -34,6 +32,9 @@
     "sha.js": "^2.4.11"
   },
   "devDependencies": {
+    "@types/crc": "^3.4.0",
+    "@types/sha.js": "^2.4.0",
+    "@types/jest": "^26.0.23",
     "@types/node": "^14.14.25",
     "jest": "^26.6.3",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
moved 

```
    "@types/crc": "^3.4.0",
    "@types/sha.js": "^2.4.0",
```

to dev deps.

also added  `"@types/jest": "^26.0.23"` as tests didn't want to run without it