### PR TITLE
Adding Node types to cbor encoders (WIP)

### DIFF
--- a/src/encodingMethods/CborEncoding.ts
+++ b/src/encodingMethods/CborEncoding.ts
@@ -12,28 +12,15 @@ interface inputOptions {
   cborLibDecoderOptions?: DecodeOptions;
 }
 
-// Current CBOR2 functions
-function assertU8(contents: unknown): asserts contents is Uint8Array {
-  if (!(contents instanceof Uint8Array)) {
-    throw new Error(`Expected Uint8Array: ${contents}`);
-  }
-}
-
 // For Node.js we are going to convert buffer into Uint8Array
 // This code should only run in Node.js
+// TODO: Handle checking if it is Node.js or not
 registerEncoder(Buffer, (b, _writer, _options) => {
   // Conver buffer to Uint8Array
   const u8 = new Uint8Array(b);
   // This is a major type ( MT.BYTE_STRING ) so no tag is given
   return [NaN, u8]
 });
-
-// Override existing Uint8Array decoder
-// Tag.registerDecoder(64, (tag: Tag): Uint8Array => {
-//   assertU8(tag.contents);
-//   return tag.contents;
-// }, 'uint8 Typed Array');
-
 
 export class CborEncoding<T extends RegistryItem>
   implements IEncodingMethod<T, Buffer>

--- a/src/encodingMethods/CborEncoding.ts
+++ b/src/encodingMethods/CborEncoding.ts
@@ -2,7 +2,8 @@ import { URRegistry, globalUrRegistry } from "../registry.js";
 import { RegistryItem, RegistryItemClass } from "../classes/RegistryItem.js";
 import { EncodingMethodName } from "../enums/EncodingMethodName.js";
 import { IEncodingMethod } from "../interfaces/IEncodingMethod.js";
-import { decode, DecodeOptions, encode, EncodeOptions } from "cbor2";
+import { decode, DecodeOptions, encode, EncodeOptions, } from "cbor2";
+import {registerEncoder, writeUint8Array} from 'cbor2/encoder';
 import { Tag } from "cbor2/tag";
 
 interface inputOptions {
@@ -10,6 +11,29 @@ interface inputOptions {
   cborLibEncoderOptions?: EncodeOptions;
   cborLibDecoderOptions?: DecodeOptions;
 }
+
+// Current CBOR2 functions
+function assertU8(contents: unknown): asserts contents is Uint8Array {
+  if (!(contents instanceof Uint8Array)) {
+    throw new Error(`Expected Uint8Array: ${contents}`);
+  }
+}
+
+// For Node.js we are going to convert buffer into Uint8Array
+// This code should only run in Node.js
+registerEncoder(Buffer, (b, _writer, _options) => {
+  // Conver buffer to Uint8Array
+  const u8 = new Uint8Array(b);
+  // This is a major type ( MT.BYTE_STRING ) so no tag is given
+  return [NaN, u8]
+});
+
+// Override existing Uint8Array decoder
+// Tag.registerDecoder(64, (tag: Tag): Uint8Array => {
+//   assertU8(tag.contents);
+//   return tag.contents;
+// }, 'uint8 Typed Array');
+
 
 export class CborEncoding<T extends RegistryItem>
   implements IEncodingMethod<T, Buffer>

--- a/tests/cbor.test.ts
+++ b/tests/cbor.test.ts
@@ -94,11 +94,11 @@ describe("CBOR Encoder", () => {
       const encoded = cbor.encode(testBuffer);
       const decoded = cbor.decode(encoded);
       // Note by default Buffer is subclass of Uint8Array, so here NODE JS assumes it as Buffer
-      // We cannot have to Buffer and Uint8Array at the same time but
+      // We cannot decode into Buffer and Uint8Array at the same time but
       // Since buffer is subclass of Uint8Array every function that can be used with Uint8Array can be used with Buffer
+      // So we can always assume its Uint8Array
       // @ts-ignore
       expect(Uint8Array.from(decoded)).toEqual(testBuffer);
-      expect(decoded).toEqual(Buffer.from(testBuffer));
     });
 
     it("should encode a Date", () => {

--- a/tests/cbor.test.ts
+++ b/tests/cbor.test.ts
@@ -80,11 +80,25 @@ describe("CBOR Encoder", () => {
       expect(decoded).toEqual(testSet);
     });
 
-    it("should encode a Buffer", () => {
-      const testBuffer = Buffer.from("hello world");
+    it("should encode a Buffer (only in nodejs)", () => {
+      const testBuffer = Buffer.from([1, 2, 3, 4]);
       const encoded = cbor.encode(testBuffer);
       const decoded = cbor.decode(encoded);
+      //@ts-ignore
+      expect(decoded.toString('hex')).toEqual(testBuffer.toString('hex'));
       expect(decoded).toEqual(testBuffer);
+    });
+
+    it("should encode a UInt8Array but decode as Buffer ( only in nodejs )", () => {
+      const testBuffer = new Uint8Array([1, 2, 3, 4]);
+      const encoded = cbor.encode(testBuffer);
+      const decoded = cbor.decode(encoded);
+      // Note by default Buffer is subclass of Uint8Array, so here NODE JS assumes it as Buffer
+      // We cannot have to Buffer and Uint8Array at the same time but
+      // Since buffer is subclass of Uint8Array every function that can be used with Uint8Array can be used with Buffer
+      // @ts-ignore
+      expect(Uint8Array.from(decoded)).toEqual(testBuffer);
+      expect(decoded).toEqual(Buffer.from(testBuffer));
     });
 
     it("should encode a Date", () => {


### PR DESCRIPTION
Register Buffer encoder as `MT.BYTE_STRING` ( Uint8Array) so cbor2 library correctly handles Buffer types.

TODO: this should only work on nodejs environment.