### PR TITLE
fix(ci): missing NPM_TOKEN error

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Dry-run release
         run: npx semantic-release --dry-run
         env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ github.token }}
           NPMJS_NPM_CONFIG_REGISTRY: https://registry.npmjs.org
           NPMJS_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Publish and create a GitHub release
         run: npx semantic-release
         env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ github.token }}
           NPMJS_NPM_CONFIG_REGISTRY: https://registry.npmjs.org
           NPMJS_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The release pipeline was failing because NPM_TOKEN was missing in the env variables. Ideally, since we use `@amanda-mitchell/semantic-release-npm-multiple`, this shouldn't be necessary but it seems that the underlying `@semantic-release/npm` requires it.