### PR TITLE
chore(ci): update workflow actions to support node 24

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -8,7 +8,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Dry-run release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Dry-run cannot be be triggered on the release branch
     if: github.ref != 'refs/heads/release'
     # GH Token permissions as required by semantic-release
@@ -20,7 +20,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all branches
 
@@ -28,7 +28,7 @@ jobs:
         run: git fetch origin release:refs/remotes/origin/release
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # GH Token permissions as required by semantic-release
     # https://github.com/semantic-release/github?tab=readme-ov-file#github-authentication
     permissions:
@@ -21,10 +21,10 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.x'
 

--- a/.github/workflows/sync-main-branch.yml
+++ b/.github/workflows/sync-main-branch.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create PR from release to main
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,12 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'yarn'


### PR DESCRIPTION
Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/